### PR TITLE
fix(generator): make directory failure after initial generation

### DIFF
--- a/src/Console/BlockMakeCommand.php
+++ b/src/Console/BlockMakeCommand.php
@@ -65,7 +65,9 @@ class BlockMakeCommand extends GeneratorCommand
 
 			$content = str_replace($find, $replace, $content);
 
-			$this->files->makeDirectory($path);
+            if (!$this->files->exists($path)) {
+                $this->files->makeDirectory($path);
+            }
 
 			file_put_contents($path . $name . '.blade.php', $content);
 		} else {


### PR DESCRIPTION
## Overview

Hello there. It seems a very recent change to the generator command actually has a pretty large bug. First generation works fine (assuming the directory `resources/views/storyblok/blocks` doesn't exist. When generating a second block, the operation fails on the make directory step of the process. This is because it is not currently checking for the presence of the directory before trying to create. This PR should address this error by checking for existence of directory before creating it.

## Steps to Reproduce

With a fresh Storybook space, a fresh laravel project, and fresh package installation, execute the following:

- `php artisan ls:block Feature -b`
- `php artisan ls:block Teaser -b`

## Expected Behavior

When generating blocks using the `ls:block` command, we should be able to generate new blocks.

## Actual Behavior

When generating a block after the `resources/views/storyblok/blocks` directory exists causes the error:

```
   ErrorException

  mkdir(): File exists

  at vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php:581
    577▕         if ($force) {
    578▕             return @mkdir($path, $mode, $recursive);
    579▕         }
    580▕
  ➜ 581▕         return mkdir($path, $mode, $recursive);
    582▕     }
    583▕
    584▕     /**
    585▕      * Move a directory.

      +16 vendor frames
  17  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

## Fix

The fix first checks for existence of directory before trying to make it (very similar to how the scss generation works below).