### PR TITLE
feat: add new sync command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-		"embed/embed": "^3.4",
         "ext-json": "*",
+        "barryvdh/reflection-docblock": "^2.0",
+        "embed/embed": "^3.4",
         "illuminate/support": "^6.0|^7.0|^8.0",
         "league/commonmark": "^1.5",
         "mundschenk-at/php-typography": "^6.5",

--- a/src/Console/BlockSyncCommand.php
+++ b/src/Console/BlockSyncCommand.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Riclep\Storyblok\Console;
+
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Context;
+use Barryvdh\Reflection\DocBlock\Serializer;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class BlockSyncCommand extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ls:sync {component?} {--path=app/Storyblok/Blocks/}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync Storyblok attributes to Laravel block classes.';
+    /**
+     * @var Filesystem
+     */
+    private Filesystem $files;
+
+    /**
+     * Create a new command instance.
+     * @param  Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $components = [];
+        if ($this->argument('component')) {
+            $components = [
+                [
+                    'class' => $this->argument('component'),
+                    'component' => Str::of($this->argument('component'))->kebab(),
+                ]
+            ];
+        } else {
+            // get all components
+            if ($this->confirm("Do you wish to update all components in {$this->option('path')}?")) {
+                $components = $this->getAllComponents();
+            }
+        }
+
+        foreach ($components as $component) {
+            $this->info("Updating {$component['component']}");
+            $this->updateComponent($component);
+        }
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getAllComponents()
+    {
+        $path = $this->option('path');
+
+        $files = collect($this->files->allFiles($path));
+
+        return $files->map(function ($file) {
+            return [
+                'class' => Str::of($file->getFilename())->replace('.php', ''),
+                'component' => Str::of($file->getFilename())->replace('.php', '')->kebab(),
+            ];
+        });
+    }
+
+    private function updateComponent($component): void
+    {
+        $rootNamespace = "App\Storyblok\Blocks";
+        $class = "{$rootNamespace}\\{$component['class']}";
+
+        $reflection = new \ReflectionClass($class);
+        $namespace = $reflection->getNamespaceName();
+        $path = $this->option('path');
+        $originalDoc = $reflection->getDocComment();
+
+        $filepath = $path.$component['class'].'.php';
+
+        $phpdoc = new DocBlock($reflection, new Context($namespace));
+
+        $tags = $phpdoc->getTagsByName('property-read');
+
+        // Clear old attributes
+        foreach ($tags as $tag) {
+            $phpdoc->deleteTag($tag);
+        }
+
+        // Add new attributes
+        $fields = $this->getComponentFields($component['component']);
+        foreach ($fields as $field => $type) {
+            $tagLine = trim("@property-read {$type} {$field}");
+            $tag = Tag::createInstance($tagLine, $phpdoc);
+
+            $phpdoc->appendTag($tag);
+        }
+
+        // Add default description if none exists
+        if ( ! $phpdoc->getText()) {
+            $phpdoc->setText("Class representation for Storyblok {$component['component']} component.");
+        }
+
+        // Write to file
+        if ($this->files->exists($filepath)) {
+            $serializer = new Serializer();
+            $updatedBlock = $serializer->getDocComment($phpdoc);
+
+            $content = $this->files->get($filepath);
+
+            $content = str_replace($originalDoc, $updatedBlock, $content);
+
+            $this->files->replace($filepath, $content);
+            $this->info('Component updated successfully.');
+        } else {
+            $this->error('Component not yet created...');
+        }
+    }
+
+    protected function getComponentFields($name)
+    {
+        if (config('storyblok.oauth_token')) {
+            $components = Cache::remember('lsb-compontent-list', 600, function () {
+                $managementClient = new \Storyblok\ManagementClient(config('storyblok.oauth_token'));
+
+                return collect($managementClient->get('spaces/'.config('storyblok.space_id').'/components')->getBody()['components']);
+            });
+
+            $component = $components->firstWhere('name', $name);
+
+            $fields = [];
+            foreach ($component['schema'] as $name => $data) {
+                if ( ! $this->isIgnoredType($data['type'])) {
+                    $fields[$name] = $this->convertToPhpType($data['type']);
+                }
+            }
+
+            return $fields;
+        } else {
+            $this->error("Please set your management token in the storkyblok config file");
+            return [];
+        }
+    }
+
+    /**
+     * Convert Storyblok types to PHP native types for proper type-hinting
+     *
+     * @param $type
+     * @return string
+     */
+    protected function convertToPhpType($type)
+    {
+        switch ($type) {
+            case "bloks":
+                return "array";
+            default:
+                return "string";
+        }
+    }
+
+    /**
+     * There are certain Storyblok types that are not useful to model in our component classes. We can use this to
+     * filter those types out.
+     *
+     * @param $type
+     * @return bool
+     */
+    protected function isIgnoredType($type)
+    {
+        $ignored = ['section'];
+
+        return in_array($type, $ignored);
+    }
+
+}

--- a/src/Console/BlockSyncCommand.php
+++ b/src/Console/BlockSyncCommand.php
@@ -26,7 +26,7 @@ class BlockSyncCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Sync Storyblok attributes to Laravel block classes.';
+    protected $description = 'Sync Storyblok attributes to Laravel Block classes.';
     /**
      * @var Filesystem
      */
@@ -159,7 +159,7 @@ class BlockSyncCommand extends Command
 
             return $fields;
         } else {
-            $this->error("Please set your management token in the storkyblok config file");
+            $this->error("Please set your management token in the Storyblok config file");
             return [];
         }
     }

--- a/src/StoryblokServiceProvider.php
+++ b/src/StoryblokServiceProvider.php
@@ -4,6 +4,7 @@ namespace Riclep\Storyblok;
 
 use Illuminate\Support\ServiceProvider;
 use Riclep\Storyblok\Console\BlockMakeCommand;
+use Riclep\Storyblok\Console\BlockSyncCommand;
 use Storyblok\Client;
 
 class StoryblokServiceProvider extends ServiceProvider
@@ -29,6 +30,7 @@ class StoryblokServiceProvider extends ServiceProvider
 
 		$this->commands([
 			BlockMakeCommand::class,
+			BlockSyncCommand::class,
 		]);
     }
 


### PR DESCRIPTION

## Overview

This PR introduces a new laravel-storyblok CLI command:

```
php artisan ls:sync
```

This command will allow the syncing of property fields of one or all of the components in a given project.

## Process

This command will look at all blocks in a project (path configurable) and then pull all components from the Storyblok management API and try and update all of the properties non-destructively. You can also optionally pass a component name in the same format as the `make` command to update only the fields for that component.

## Context

We are starting to use Storyblok in a fairly large project and found maintaining the fields for all components to be quite a drag. We are using your package and found it the perfect place to integrate this type of functionality as it already relies on the Management API for some operations.

## Screenshots

### Command Signature

![image](https://user-images.githubusercontent.com/1449463/110516855-b9e04380-80cf-11eb-8e4a-f0158efc961c.png)

### Syncing 1 Component

```
php artisan ls:sync Grid
```

![image](https://user-images.githubusercontent.com/1449463/110516988-e1cfa700-80cf-11eb-9c3c-05ae52c48a2f.png)


### Syncing All Components

```
php artisan ls:sync
```

![image](https://user-images.githubusercontent.com/1449463/110517035-f1e78680-80cf-11eb-8f21-b519780a4f8a.png)
