### PR TITLE
feat: add support for custom asset domain

### DIFF
--- a/config/storyblok.php
+++ b/config/storyblok.php
@@ -91,7 +91,7 @@ return [
 
 	/*
     |--------------------------------------------------------------------------
-    | Cache duration
+    | Component class namespace
     |--------------------------------------------------------------------------
     |
     | Sets the namespace for the Page and Block classes
@@ -101,7 +101,7 @@ return [
 
 	/*
     |--------------------------------------------------------------------------
-    | Cache duration
+    | View folder path
     |--------------------------------------------------------------------------
     |
     | Sets the folder where views will be stored under /resources/views
@@ -111,14 +111,35 @@ return [
 
 	/*
     |--------------------------------------------------------------------------
-    | Cache duration
+    | Webhook secret
     |--------------------------------------------------------------------------
     |
-    | Sets the folder where views will be stored under /resources/views
+    | Webhook from space settings
+    | https://www.storyblok.com/docs/guide/in-depth/webhooks
     |
     */
 	'webhook_secret' => env('STORYBLOK_WEBHOOK_SECRET'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Asset domain
+    |--------------------------------------------------------------------------
+    |
+    | Storyblok asset URL, can be customized if proxy is setup
+    | https://www.storyblok.com/docs/custom-assets-domain
+    |
+    */
+    'asset_domain' => env('STORYBLOK_ASSET_DOMAIN', 'a.storyblok.com'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image service domain
+    |--------------------------------------------------------------------------
+    |
+    | Can be customized to proxy image service requests over a custom domain
+    |
+    */
+    'image_service_domain' => env('STORYBLOK_IMAGE_SERVICE_DOMAIN', 'img2.storyblok.com'),
 
 
 ];

--- a/src/Fields/Asset.php
+++ b/src/Fields/Asset.php
@@ -11,6 +11,15 @@ use Riclep\Storyblok\Field;
  */
 class Asset extends Field
 {
+	public function __construct($content, $block)
+	{
+		parent::__construct($content, $block);
+
+		if (isset($this->content['filename'])) {
+			$this->content['filename'] = str_replace('a.storyblok.com', config('storyblok.asset_domain'), $this->content['filename']);
+        }
+	}
+
 	public function __toString()
 	{
 		if ($this->content['filename']) {

--- a/src/Support/ImageTransformation.php
+++ b/src/Support/ImageTransformation.php
@@ -93,8 +93,8 @@ class ImageTransformation
 	 */
 	public function createUrl($options): string
 	{
-		$resource = str_replace(['https:', '//a.storyblok.com'], '', $this->filename);
-		return '//img2.storyblok.com' . $options . $resource;
+		$resource = str_replace(['https:', '//' . config('storyblok.asset_domain')], '', $this->filename);
+		return '//' . config('storyblok.image_service_domain') . $options . $resource;
 	}
 
 	public function getTransformations() {

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -112,6 +112,15 @@ class FieldTest extends TestCase
 	}
 
 	/** @test */
+	public function can_get_image_asset_as_url_with_custom_domain()
+	{
+		config()->set('storyblok.asset_domain', 'custom.asset.domain');
+		$field = new Image($this->getFieldContents('asset_image'), null);
+
+		$this->assertEquals('https://custom.asset.domain/f/52681/700x700/97f51f6374/blood-cells.jpg', (string) $field);
+	}
+
+	/** @test */
 	public function can_get_image_asset_dimensions()
 	{
 		$field = new Image($this->getFieldContents('hero'), null);
@@ -178,6 +187,17 @@ class FieldTest extends TestCase
 		$field3 = $field3->transform()->fitIn(400, 400, 'transparent')->format('webp');
 
 		$this->assertEquals('//img2.storyblok.com/fit-in/400x400/filters:format(webp):fill(transparent)/f/87028/960x1280/31a1d8dc75/bottle.jpg', (string) $field3);
+	}
+
+	/** @test */
+	public function can_use_custom_image_service_domain()
+	{
+		config()->set('storyblok.image_service_domain', 'custom.imageservice.domain');
+
+		$field = new Image($this->getFieldContents('hero'), null);
+		$field = $field->transform()->fitIn(400, 400, 'ff0000');
+
+		$this->assertEquals('//custom.imageservice.domain/fit-in/400x400/filters:fill(ff0000)/f/87028/960x1280/31a1d8dc75/bottle.jpg', (string) $field);
 	}
 
 	/** @test */
@@ -254,6 +274,25 @@ PICTURE
 	}
 
 	/** @test */
+	public function can_get_create_picture_element_with_custom_domains()
+	{
+		config()->set('storyblok.asset_domain', 'custom.asset.domain');
+		config()->set('storyblok.image_service_domain', 'custom.imageservice.domain');
+
+		$field = new HeroImage($this->getFieldContents('hero'), null);
+
+		$this->assertEquals(<<<'PICTURE'
+<picture>
+<source srcset="//custom.imageservice.domain/100x120/filters:format(webp)/f/87028/960x1280/31a1d8dc75/bottle.jpg" type="image/webp" media="(min-width: 600px)">
+<source srcset="//custom.imageservice.domain/500x400/f/87028/960x1280/31a1d8dc75/bottle.jpg" type="image/jpeg" media="(min-width: 1200px)">
+
+<img src="https://custom.asset.domain/f/87028/960x1280/31a1d8dc75/bottle.jpg" alt="Some alt text with &quot;" >
+</picture>
+PICTURE
+, str_replace("\t", '', $field->picture('Some alt text with "')));
+	}
+
+	/** @test */
 	public function can_get_asset_url_with_accessor()
 	{
 		$field = new AssetWithAccessor($this->getFieldContents('asset'), null);
@@ -291,6 +330,18 @@ PICTURE
 
 		$field = new MultiAsset($this->getFieldContents('multi_assets'), $block);
 		$this->assertEquals('https://a.storyblok.com/f/52681/1000x875/7ced1a10b2/blow-dry-mobile.jpg', $field[0]->filename);
+	}
+
+	/** @test */
+	public function can_use_array_access_on_multi_asset_with_custom_domain()
+	{
+		config()->set('storyblok.asset_domain', 'custom.asset.domain');
+
+		$page = $this->makePage('custom-page.json');
+		$block = $page->block(); // any parent block will for for testing
+
+		$field = new MultiAsset($this->getFieldContents('multi_assets'), $block);
+		$this->assertEquals('https://custom.asset.domain/f/52681/1000x875/7ced1a10b2/blow-dry-mobile.jpg', $field[0]->filename);
 	}
 
 	/** @test */


### PR DESCRIPTION
Introduces the ability to use custom domains for Storyblok assets.

Two new config values:
`asset_domain` which can be modified from the default `a.storyblok.com`
`image_service_domain` which can be modified from the default `img2.storyblok.com`

The configuration to customize both domains is needed because:

1. [Storyblok documentation on setting up the custom asset domain](https://www.storyblok.com/docs/custom-assets-domain) links a CloudFront distribution directly to the S3 bucket, bypassing the image service.
2. Non-image assets cannot pass through the image service, so you cannot pass all asset requests through `img2.storyblok.com`

In my use case, I'll have two rules set up on my domain to route requests to either `a.storyblok.com` or `img2.storyblok.com` based on the URL path.