### PR TITLE
feat(console): add component listing artisan command

### DIFF
--- a/src/Console/ComponentViewCommand.php
+++ b/src/Console/ComponentViewCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Riclep\Storyblok\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ComponentViewCommand extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ls:component-list
+	            {--additional-fields= : Additional fields to pull form Storyblok Management API}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all storyblok components.';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $managementClient = new \Storyblok\ManagementClient(config('storyblok.oauth_token'));
+
+        $resp = $managementClient->get('spaces/'.config('storyblok.space_id').'/components');
+        $components = collect($resp->getBody()['components']);
+
+        $additionalFields = $this->option('additional-fields') ?
+            Str::of($this->option('additional-fields'))->explode(',')
+            : collect();
+
+        $rows = $components->map(function ($c) use ($additionalFields) {
+            $mapped = [
+                'name' => $c['name'],
+                'display_name' => $c['display_name'],
+                'has_image' => $c['image'] ? "<fg=green>true</>" : '<fg=red>false</>',
+                'has_template' => $c['preview_tmpl'] ? "<fg=green>true</>" : '<fg=red>false</>',
+            ];
+
+            $mappedAdditional = collect($c)->only($additionalFields);
+
+            return array_merge($mapped, $mappedAdditional->toArray());
+        });
+
+        $this->table(
+            array_keys($rows->first()),
+            $rows
+        );
+    }
+
+}

--- a/src/StoryblokServiceProvider.php
+++ b/src/StoryblokServiceProvider.php
@@ -5,6 +5,7 @@ namespace Riclep\Storyblok;
 use Illuminate\Support\ServiceProvider;
 use Riclep\Storyblok\Console\BlockMakeCommand;
 use Riclep\Storyblok\Console\BlockSyncCommand;
+use Riclep\Storyblok\Console\ComponentViewCommand;
 use Riclep\Storyblok\Console\StubViewsCommand;
 use Storyblok\Client;
 
@@ -33,6 +34,7 @@ class StoryblokServiceProvider extends ServiceProvider
 			BlockMakeCommand::class,
 			BlockSyncCommand::class,
 			StubViewsCommand::class,
+			ComponentViewCommand::class,
 		]);
     }
 


### PR DESCRIPTION

## Overview

This PR adds a simple component listing command that could be useful for folks trying to get quick introspection into their Storyblok environment.

## Usage

```
Description:
  List all storyblok components.

Usage:
  ls:component-list [options]

Options:
      --additional-fields[=ADDITIONAL-FIELDS]  Additional fields to pull form Storyblok Management API
  -h, --help                                   Display help for the given command. When no command is given display help for the list command
  -q, --quiet                                  Do not output any message
  -V, --version                                Display this application version
      --ansi                                   Force ANSI output
      --no-ansi                                Disable ANSI output
  -n, --no-interaction                         Do not ask any interactive question
      --env[=ENV]                              The environment the command should run under
  -v|vv|vvv, --verbose                         Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

This command _does_ allow passing additional fields that will be automatically mapped into the table for folks that would like additional details not given by default.

Additional fields can be found in their [Management API Docs](https://www.storyblok.com/docs/api/management#core-resources/components/components).

## Output

![image](https://user-images.githubusercontent.com/1449463/122445261-fccf7400-cf66-11eb-9839-92bea3311ef6.png)
