### PR TITLE
Fixed Caching issue for multitenancy setup

### DIFF
--- a/src/RequestStory.php
+++ b/src/RequestStory.php
@@ -32,7 +32,8 @@ class RequestStory
 				$cache = $cache->tags('storyblok');
 			}
 
-			$response = $cache->remember($slugOrUuid, config('storyblok.cache_duration') * 60, function () use ($slugOrUuid) {
+			$api_hash = md5(config('storyblok.api_public_key') ?? config('storyblok.api_preview_key' ));
+			$response = $cache->remember($slugOrUuid . '_' . $api_hash , config('storyblok.cache_duration') * 60, function () use ($slugOrUuid) {
 				return $this->makeRequest($slugOrUuid);
 			});
 		}


### PR DESCRIPTION
We are using a multitenancy setup connected to multiple Storyblok spaces.
To load the contents of different spaces, we change the STORYBLOK_PREVIEW_API_KEY and STORYBLOK_PUBLIC_API_KEY at runtime. This works perfectly!

But the caching key cannot be changed outside of this package. As a result, switching between spaces does not work. After all, the cache_key hasn't changed.

To avoid this we thought it would be a good idea to use the api_keys in addition to the slug

What do you think of this simple yet effective solution? Can it be merged, so that laravel-storyblock is also suitable for multi-tenancy setups