### PR TITLE
Use https in the storyblok client

### DIFF
--- a/src/StoryblokServiceProvider.php
+++ b/src/StoryblokServiceProvider.php
@@ -64,9 +64,9 @@ class StoryblokServiceProvider extends ServiceProvider
 
         // register the Storyblok client, checking if we are in edit more of the dev requests draft content
 		if (config('storyblok.draft')) {
-			$client = new Client(config('storyblok.api_preview_key'));
+			$client = new Client(config('storyblok.api_preview_key'), "api.storyblok.com", "v1", true);
 		} else {
-			$client = new Client(config('storyblok.api_public_key'));
+			$client = new Client(config('storyblok.api_public_key'), "api.storyblok.com", "v1", true);
 		}
 
 	    // if we’re in Storyblok’s edit mode let’s save that in the config for easy access


### PR DESCRIPTION
The Storyblok Client defaults to using http instead of https. This change makes it use https. If you'd prefer this to be configurable instead, I can update the PR.

The ManagementClient doesn't let you set the variable to true. I added an issue to their project [here](https://github.com/storyblok/php-client/issues/39) and will make another PR for that one once they fix it.