### PR TITLE
fix: php 8.1 deprecation notices

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -299,7 +299,7 @@ class Block implements \IteratorAggregate, \JsonSerializable
 	 *
 	 * @return \Traversable
 	 */
-	public function getIterator() {
+	public function getIterator(): \Traversable {
 		return $this->_fields;
 	}
 

--- a/src/Block.php
+++ b/src/Block.php
@@ -288,7 +288,7 @@ class Block implements \IteratorAggregate, \JsonSerializable
 	 *
 	 * @return Collection|mixed
 	 */
-	public function jsonSerialize()
+	public function jsonSerialize(): mixed
 	{
 		return $this->content();
 	}

--- a/src/Fields/MultiAsset.php
+++ b/src/Fields/MultiAsset.php
@@ -119,7 +119,7 @@ class MultiAsset extends Field implements \ArrayAccess, \Iterator, \Countable
 	/*
 	 * Countable trait
 	 * */
-	public function count()
+	public function count(): int
 	{
 		return $this->content->count();
 	}


### PR DESCRIPTION
## Overview

This PR should make the necessary minor changes to allow PHP 8.1. Without adding these return types, the package will throw Deprecation notices.

For full changelog, check out the notes [here](https://www.php.net/manual/en/migration81.incompatible.php).

### Context

Here is an example error that is being thrown when using PHP 8.1:

```
Return type of Riclep\Storyblok\Block::getIterator() should either be compatible with IteratorAggregate::getIterator(): 
Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```