### PR TITLE
fix: upgrade storyblok richtext resolver to v2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	    "league/commonmark": "^2.0",
 	    "spatie/schema-org": "^3.3",
 	    "storyblok/php-client": "^2.3",
-	    "storyblok/richtext-resolver": "2.0.0"
+	    "storyblok/richtext-resolver": "2.1.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",


### PR DESCRIPTION
Upgrades `storyblok/richtext-resolver` to version 2.1 which fixes [some bugs](https://github.com/storyblok/storyblok-php-richtext-renderer/releases/tag/2.1.0).