### PR TITLE
fix for case sensitive extensions in multi assets

### DIFF
--- a/src/Fields/MultiAsset.php
+++ b/src/Fields/MultiAsset.php
@@ -38,7 +38,7 @@ class MultiAsset extends Field implements \ArrayAccess, \Iterator, \Countable
 	{
 		if ($this->hasFiles()) {
 			$this->content = collect($this->content())->transform(function ($file) {
-				if (Str::endsWith($file['filename'], ['.jpg', '.jpeg', '.png', '.gif', '.webp'])) {
+				if (Str::endsWith(Str::lower($file['filename']), ['.jpg', '.jpeg', '.png', '.gif', '.webp'])) {
 					if ($class = $this->getChildClassName('Field', $this->block()->component() . 'Image')) {
 						return new $class($file, $this->block());
 					}


### PR DESCRIPTION
This pull request fixes an issue where a storyblok user uploads media where the extension is capitalized (my-image.PNG) 