### PR TITLE
fix folder cache issue for multitenancy installations

### DIFF
--- a/src/Folder.php
+++ b/src/Folder.php
@@ -214,9 +214,10 @@ abstract class Folder
 		if (request()->has('_storyblok') || !config('storyblok.cache')) {
 			$response = $this->makeRequest();
 		} else {
-			$uniqueTag = md5(serialize($this->getSettings()));
+			$apiHash = md5(config('storyblok.api_public_key') ?? config('storyblok.api_preview_key')); // unique id for multitenancy applications
+            $uniqueTag = md5(serialize($this->getSettings()));
 
-			$response = Cache::remember($this->cacheKey . $this->slug . '-' . $uniqueTag, config('storyblok.cache_duration') * 60, function () {
+			$response = Cache::remember($this->cacheKey . $this->slug . '-' . $apiHash . '-' . $uniqueTag, config('storyblok.cache_duration') * 60, function () {
 				return $this->makeRequest();
 			});
 		}


### PR DESCRIPTION
Howdy,

This pull-request fixes an cache issue for multitenancy installations and Folders.
The folder cache key was not unique when multiple sites where pointing to the same Laravel installation and where using the same slug. 

To avoid this we thought it would be a good idea to use the api_keys in addition to the slug for creating an unique cache key.