### PR TITLE
Added 404 responce

### DIFF
--- a/src/Http/Controllers/LiveContentController.php
+++ b/src/Http/Controllers/LiveContentController.php
@@ -18,9 +18,16 @@ class LiveContentController
 	 */
 	public function show(Request $request): string
     {
-		config(['storyblok.edit_mode' => true]);
 
-		$page = Storyblok::setData($request->get('data')['story'])->render();
+        $data = $request->input('data');
+
+        if (!isset($data['story'])) {
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(response()->json(['message' => 'Story not found'], 404));
+        }
+
+        config(['storyblok.edit_mode' => true]);
+
+		$page = Storyblok::setData($data['story'])->render();
 		$dom = new HTML5DOMDocument();
 		$dom->loadHTML($page);
 


### PR DESCRIPTION
I've added a 'not found' error response for cases where a story cannot be found. This fix addresses issues with the Exchange autodiscover service, which previously sent numerous POST requests to /autodiscover.xml, inadvertently causing a 500 error. By implementing a 'not found' error response, we now prevent these errors, ensuring the system operates more smoothly and reliably.

This solution not only resolves my specific issue but also, on a broader scale, it is more appropriate to return a specific error message instead of a generic 500 server error. Providing a precise error message enhances the user experience by clearly indicating when something cannot be found. This contributes to more efficient error handling and makes the system more transparent and user-friendly.