### PR TITLE
Codyworthen/new region api config variable

### DIFF
--- a/config/storyblok.php
+++ b/config/storyblok.php
@@ -37,6 +37,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Specify which Content Delivery API region-specific base URL to use
+    |--------------------------------------------------------------------------
+    |
+    | Defaults to api.storyblok.com which should be the original EU region
+    |
+    */
+    'content_delivery_api_base_url' => 'api.storyblok.com',
+
+    /*
+    |--------------------------------------------------------------------------
     | Use SSL when calling the Storyblok API
     |--------------------------------------------------------------------------
     |

--- a/config/storyblok.php
+++ b/config/storyblok.php
@@ -43,7 +43,17 @@ return [
     | Defaults to api.storyblok.com which should be the original EU region
     |
     */
-    'content_delivery_api_base_url' => 'api.storyblok.com',
+    'delivery_api_base_url' => 'api.storyblok.com',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Specify which Management API region-specific base URL to use
+    |--------------------------------------------------------------------------
+    |
+    | Defaults to mapi.storyblok.com which should be the original EU region
+    |
+    */
+    'management_api_base_url' => 'mapi.storyblok.com',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/BlockSyncCommand.php
+++ b/src/Console/BlockSyncCommand.php
@@ -142,7 +142,11 @@ class BlockSyncCommand extends Command
 	protected function getComponentFields($name): array
 	{
 		if (config('storyblok.oauth_token')) {
-			$managementClient = new \Storyblok\ManagementClient(config('storyblok.oauth_token'));
+			$managementClient = new \Storyblok\ManagementClient(
+                apiKey:config('storyblok.oauth_token'),
+                apiEndpoint: config('storyblok.management_api_base_url'),
+                ssl: config('storyblok.use_ssl'),
+            );
 
 			$components = collect($managementClient->get('spaces/'.config('storyblok.space_id').'/components')->getBody()['components']);
 
@@ -177,7 +181,11 @@ class BlockSyncCommand extends Command
 	 * @throws ApiException
 	 */
 	protected function createStoryblokCompontent($component_name){
-        $managementClient = new \Storyblok\ManagementClient(config('storyblok.oauth_token'));
+        $managementClient = new \Storyblok\ManagementClient(
+            apiKey:config('storyblok.oauth_token'),
+            apiEndpoint: config('storyblok.management_api_base_url'),
+            ssl: config('storyblok.use_ssl'),
+        );
 
         $payload = [
 			"component" =>  [

--- a/src/Console/StubViewsCommand.php
+++ b/src/Console/StubViewsCommand.php
@@ -46,7 +46,11 @@ class StubViewsCommand extends Command
 	{
 		$this->makeDirectories();
 
-		$client = new ManagementClient(config('storyblok.oauth_token'));
+		$client = new ManagementClient(
+            apiKey:config('storyblok.oauth_token'),
+            apiEndpoint: config('storyblok.management_api_base_url'),
+            ssl: config('storyblok.use_ssl'),
+        );
 
 		$components = collect($client->get('spaces/' . config('storyblok.space_id') . '/components/')->getBody()['components']);
 

--- a/src/StoryblokServiceProvider.php
+++ b/src/StoryblokServiceProvider.php
@@ -67,7 +67,7 @@ class StoryblokServiceProvider extends ServiceProvider
 	    // register the Storyblok client, checking if we are in edit more of the dev requests draft content
 	    $client = new Client(
 			config('storyblok.draft') ? config('storyblok.api_preview_key') : config('storyblok.api_public_key'),
-			"api.storyblok.com", "v2", config('storyblok.use_ssl'), config('storyblok.api_region')
+            config('storyblok.content_delivery_api_base_url'), "v2", config('storyblok.use_ssl'), config('storyblok.api_region')
 	    );
 
 	    // if we’re in Storyblok’s edit mode let’s save that in the config for easy access

--- a/src/StoryblokServiceProvider.php
+++ b/src/StoryblokServiceProvider.php
@@ -67,7 +67,7 @@ class StoryblokServiceProvider extends ServiceProvider
 	    // register the Storyblok client, checking if we are in edit more of the dev requests draft content
 	    $client = new Client(
 			config('storyblok.draft') ? config('storyblok.api_preview_key') : config('storyblok.api_public_key'),
-            config('storyblok.content_delivery_api_base_url'), "v2", config('storyblok.use_ssl'), config('storyblok.api_region')
+            config('storyblok.delivery_api_base_url'), "v2", config('storyblok.use_ssl'), config('storyblok.api_region')
 	    );
 
 	    // if we’re in Storyblok’s edit mode let’s save that in the config for easy access


### PR DESCRIPTION
- Added config variables for the Content Delivery API base URL and the Management API base URL
  - Previously, `"api.storyblok.com"` was hard-coded into the `StoryblokServiceProvider`. 
    - This is the Content Delivery API base URL for the 'eu' region.
    - Changing the existing config variable `storyblok.api_region` to have the value `"us"` had no effect on the base URL used by the Storyblok client due to a bug in `BaseClient`'s private `generateEndpoint` method. 
    - 
- The bug is that `$apiEndpoint` is never falsey, since the hardcoded value `"api.storyblok.com"` is always present. Therefore, modifying the config variable `storyblok.api_region` was not resulting in the correct base url being used.
```
if (!$apiEndpoint) {
    $region = $apiRegion ? "-{$apiRegion}" : '';
    $apiEndpoint = "api{$region}.storyblok.com";
}
```

- to keep things simple, I did not try to fix the bug in the `BaseClient`'s `generateEndpoint` method, but I did add a config variable for both of the Storyblok API base URL's.
 - I then made sure to pass the appropriate config variable into the `ManagementClient` as well for the Artisan command tools