### PR TITLE
fix(Block): added relation resolution to Block's inverseRelation method

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -449,9 +449,10 @@ class Block implements \IteratorAggregate, \JsonSerializable
 	 * @param string $foreignRelationshipType
 	 * @param array|null $components
 	 * @param array|null $options
+     * @param array|null $resolveRelations
 	 * @return array
 	 */
-    public function inverseRelation(string $foreignRelationshipField, string $foreignRelationshipType = 'multi', array $components = null, array $options = null): array
+    public function inverseRelation(string $foreignRelationshipField, string $foreignRelationshipType = 'multi', array $components = null, array $options = null, array $resolveRelations = null): array
     {
         $storyblokClient = resolve('Storyblok\Client');
 
@@ -477,6 +478,10 @@ class Block implements \IteratorAggregate, \JsonSerializable
 
         if ($options) {
             $query = array_merge_recursive($query, $options);
+        }
+
+        if ($resolveRelations) {
+            $storyblokClient->resolveRelations(implode(',', $resolveRelations));
         }
 
         if (request()->has('_storyblok') || !config('storyblok.cache')) {


### PR DESCRIPTION
I have found that it's useful to have `Block.php`'s  inverseRelation method accept an argument for resolving relations, both for "real" storyblok api requests, as well as when dealing with Live Editor JSON that may come from storyblok because storyblok doesn't resolve relations by default.