### PR TITLE
fixed bug with editor-bridge.blade.php

### DIFF
--- a/config/storyblok.php
+++ b/config/storyblok.php
@@ -251,6 +251,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Allow live preview links
+    |--------------------------------------------------------------------------
+    |
+    | Links in the visual editor will be clickable and navigate to the page
+    | with the Storyblok editing query string appended
+    |
+    */
+    'live_links' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Name of the field to be used for settings
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/LiveContentController.php
+++ b/src/Http/Controllers/LiveContentController.php
@@ -29,7 +29,7 @@ class LiveContentController
 
 		$page = Storyblok::setData($data['story'])->render();
 		$dom = new HTML5DOMDocument();
-		$dom->loadHTML($page);
+        $dom->loadHTML($page, HTML5DOMDocument::ALLOW_DUPLICATE_IDS);
 
 		return $dom->querySelector(config('storyblok.live_element'))->innerHTML;
 	}

--- a/src/resources/views/editor-bridge.blade.php
+++ b/src/resources/views/editor-bridge.blade.php
@@ -13,27 +13,74 @@
 		});
 
 		@if (config('storyblok.live_preview'))
-		storyblokInstance.on('input', (event) => {
-			const CancelToken = axios.CancelToken;
-			let source = CancelToken.source();
+            storyblokInstance.on('input', (event) => {
+                const CancelToken = axios.CancelToken;
+                let source = CancelToken.source();
 
-			source && source.cancel('Operation canceled due to new request.');
+                source && source.cancel('Operation canceled due to new request.');
 
-			// save the new request for cancellation
-			source = axios.CancelToken.source();
+                // save the new request for cancellation
+                source = axios.CancelToken.source();
 
-			axios.post(@js(request()->getRequestUri()), {
-				data: event
-			}, {
-				cancelToken: source.token
-			}).then((response) => {
-				document.querySelector('{{ config('storyblok.live_element') }}').innerHTML = response.data;
+                axios.post(@js(request()->getRequestUri()), {
+                    data: event
+                }, {
+                    cancelToken: source.token
+                }).then((response) => {
+                    document.querySelector('{{ config('storyblok.live_element') }}').innerHTML = response.data;
 
-				const storyblokInstance = new StoryblokBridge({
-					accessToken: '{{ config('storyblok.api_preview_key') }}'
-				});
-			});
-		});
+                    @if (config('storyblok.live_links'))
+                        document.dispatchEvent(new Event('DOMContentLoaded'));
+                    @endif
+
+                    const storyblokInstance = new StoryblokBridge({
+                        accessToken: '{{ config('storyblok.api_preview_key') }}'
+                    });
+                });
+            });
 		@endif
+
+
+        @if (config('storyblok.live_links'))
+            function appendQueryParamsToPath(path) {
+                const link = new URL(path, window.location.origin);
+                if (link.origin !== window.location.origin) {
+                    return path;
+                }
+
+                const currentUrl = window.location.href;
+                const queryParams = currentUrl.split('?')[1];
+
+                if (queryParams) {
+                    path += (path.includes('?') ? '&' : '?') + queryParams;
+                }
+
+                return path;
+            }
+
+            function updateAllLinks() {
+                const urlParams = new URLSearchParams(window.location.search);
+                let condition = false;
+
+                for (const [key] of urlParams) {
+                    if (key.startsWith('_storyblok')) {
+                        condition = true;
+                        break;
+                    }
+                }
+
+                if (condition) {
+                    const links = document.querySelectorAll('a[href]');
+
+                    links.forEach(link => {
+                        const originalHref = link.getAttribute('href');
+                        const updatedHref = appendQueryParamsToPath(originalHref);
+                        link.setAttribute('href', updatedHref);
+                    });
+                }
+            }
+
+            document.addEventListener('DOMContentLoaded', updateAllLinks);
+        @endif
 	</script>
 @endif

--- a/src/resources/views/editor-bridge.blade.php
+++ b/src/resources/views/editor-bridge.blade.php
@@ -22,7 +22,7 @@
 			// save the new request for cancellation
 			source = axios.CancelToken.source();
 
-			axios.post('{{ url()->current() }}', {
+			axios.post(@js(request()->getRequestUri()), {
 				data: event
 			}, {
 				cancelToken: source.token


### PR DESCRIPTION
`axios.post('{{ url()->current() }}'` omits the request params that `Riclep\Storyblok\StoryblokServiceProvider` uses to override the `STORYBLOK_DRAFT` env variable to set it to `true` when the request is coming from `app.storyblok.com` 
- (see [here](https://raw.githubusercontent.com/RicLeP/laravel-storyblok/refs/heads/master/src/StoryblokServiceProvider.php#:~:text=%24storyblokRequest%20%3D%20request()%2D%3Eget(%27_storyblok_tk%27)%3B))

When a laravel application is processing a request that comes from the storyblok app (and omits the aforementioned query params e.g. `_storyblok_tk`), this bug causes the application container to register an instance of the `Storyblok\Client` that is using the `apiKey` as determined by this [line](https://raw.githubusercontent.com/RicLeP/laravel-storyblok/refs/heads/master/src/StoryblokServiceProvider.php#:~:text=%24client%20%3D%20new%20Client(%0A%09%09%09config(%27storyblok.draft%27)%20%3F%20config(%27storyblok.api_preview_key%27)%20%3A%20config(%27storyblok.api_public_key%27)%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20config(%27storyblok.delivery_api_base_url%27)%2C%20%22v2%22%2C%20config(%27storyblok.use_ssl%27)%2C%20config(%27storyblok.api_region%27)%0A%09%20%20%20%20)%3B).
- in a production environment, `STORYBLOK_DRAFT` would be set to false
- in a production environment, the `apiKey` used by the registered `Storyblok\Client` instance would be `config('storyblok.api_preview_key')` for a "regular" GET request resulting from initially loading a page in the storyblok app/editor
- in a production environment, as soon as the live editor triggers a page reload, the registered `Storyblok\Client` would then start using config('storyblok.api_public_key')

This causes some unexpected behavior when both draft and published content exist in the space, as the draft content would be fetched along with the published content on the initial page load in the editor, but then any subsequent live editor updates would re-render the page and _only_ include published content, as if all of the draft content disappeared.

1. `request()->getRequestUri()` ensures that the necessary query params set by the storyblok app are preserved when the live editor does its job. 
2. Wrapping this in a `@js()` blade directive rather than echoing it as a string prevents html entities such as `&` from being html encoded to `&amp;` 