### PR TITLE
Bugfix: Allow WebhookController to Work Without webhook_secret

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -22,7 +22,7 @@ class WebhookController
         $requestSignature = $request->header("webhook-signature");
 
         // Check if the header is neccessary and if it is set
-        if (empty($webhookSecret) && $requestSignature === null) {
+        if (!empty($webhookSecret) && $requestSignature === null) {
             throw new BadRequestHttpException("Header not set");
         }
 


### PR DESCRIPTION
## Description  
The current implementation assumes that all Storyblok plans support webhook signing, but lower-tier plans do not include this feature. As a result, webhooks fail, preventing cache clearing.

## Changes  
- The signature check is now **optional**. If no `webhook_secret` is configured, the webhook will proceed without validation.  
- The request signature and webhook secret are retrieved **once** for improved readability and maintainability.  
- If a `webhook_secret` is set, the signature check remains **fully enforced** to maintain security.  

## Impact  
- **Before:** Webhooks from lower-tier Storyblok plans **fail** due to missing signature headers, preventing cache clearing.  
- **After:** Webhooks from **all Storyblok plans** now work correctly, while security remains intact when a secret is configured.  

Let me know if any refinements are needed! 🚀