### PR TITLE
fix for live preview and spaces around html tags like <b>, <i>, links…

### DIFF
--- a/config/storyblok.php
+++ b/config/storyblok.php
@@ -274,6 +274,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Fix spaces in live preview using preg_replace
+    |--------------------------------------------------------------------------
+    |
+    | Spaces are removed in the live preview in Storyblok due to an issue with HTMLDom5
+    | Using the live_html_tags_spaces array to add spaces around those tags. Leave an empty array to skip preg_replace
+    |
+    */
+    'live_html_tags_spaces' => ['a', 'b', 'i', 'strike', 'u'],
+
+    /*
+    |--------------------------------------------------------------------------
     | Name of the field to be used for settings
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/LiveContentController.php
+++ b/src/Http/Controllers/LiveContentController.php
@@ -28,6 +28,19 @@ class LiveContentController
         config(['storyblok.edit_mode' => true]);
 
 		$page = Storyblok::setData($data['story'])->render();
+
+        // fix space removal from tags like <b>, <i> until a suitable replacement for HTML5dom has been found
+        $htmlTags = config('storyblok.live_html_tags_spaces', ['a', 'b', 'i', 'strike', 'u']);
+        if (is_array($htmlTags)) {
+            foreach ($htmlTags as $tag) {
+                // Add space before the opening tag if not already preceded by a space
+                $page = preg_replace("/(?<!\s)<$tag\b/", " <$tag", $page);
+
+                // Add space after the closing tag if not already followed by a space
+                $page = preg_replace("/<\/$tag>(?!\s)/", "</$tag> ", $page);
+            }
+        }
+
 		$dom = new HTML5DOMDocument();
         $dom->loadHTML($page, HTML5DOMDocument::ALLOW_DUPLICATE_IDS);
 


### PR DESCRIPTION
When using the live preview in Storyblok, spaces around html tags like <b>, <a> etc are removed.
This PR (temp) fixes this issue using regulair expressions